### PR TITLE
Update binding.gyp to fix "sodium.h not found" error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,7 @@
         "-lself_omemo"
       ],
       "include_dirs": [
-        "<!@(node -p \"require('node-addon-api').include\")"
+        "<!(node -p \"require('node-addon-api').include_dir\")"
       ],
       "cflags!": [
         "-fno-exceptions"


### PR DESCRIPTION
For some reason, the @ in `<!@(node -p \"require('node-addon-api').include\")` causes `node-gyp-build` to fail with:

```
gyp info spawn C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe
gyp info spawn args [
gyp info spawn args   'build/binding.sln',
gyp info spawn args   '/clp:Verbosity=minimal',
gyp info spawn args   '/nologo',
gyp info spawn args   '/p:Configuration=Release;Platform=x64'
gyp info spawn args ]
Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
  binding.cc
D:\a\self-desktop\self-desktop\src\node_modules\self-crypto\binding.cc(5,10): fatal error C1083: Cannot open include file: 'sodium.h': No such file or directory [D:\a\self-desktop\self-desktop\src\node_modules\self-crypto\build\native.vcxproj]
gyp ERR! build error 
gyp ERR! stack Error: `C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\hostedtoolcache\windows\node\15.14.0\x64\node_modules\npm\node_modules\node-gyp\lib\build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (node:events:369:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
gyp ERR! System Windows_NT 10.0.17763
gyp ERR! command "C:\\hostedtoolcache\\windows\\node\\15.14.0\\x64\\node.exe" "C:\\hostedtoolcache\\windows\\node\\15.14.0\\x64\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd D:\a\self-desktop\self-desktop\src\node_modules\self-crypto
gyp ERR! node -v v15.14.0
gyp ERR! node-gyp -v v7.1.2
gyp ERR! not ok
  stackTrace=
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  Error: C:\hostedtoolcache\windows\node\15.14.0\x64\node.exe exited with code ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
```

This PR fixes this problem by changing `include_dirs` to the value that is indicated in `node-addon-api`'s official docs: https://github.com/nodejs/node-addon-api/blob/master/doc/setup.md#installation-and-usage


